### PR TITLE
ALICE patches for ROOT6 compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,8 +38,8 @@ set(ROOT_DICT_OUTPUT_DIR ${PROJECT_SOURCE_DIR})
 # and add LinkDef file to the end
 LIST( APPEND ROOT_DICT_INPUT_HEADERS ${LINK_DEF_FILE} )
 
-# generate dictionary sources using rootcint 
-GEN_ROOT_DICT_SOURCE( ${CINTFILE} ) 
+# generate dictionary sources using rootcint
+GEN_ROOT_DICT_SOURCE( ${CINTFILE} )
 
 # get boost
 set(Boost_USE_MULTITHREADED ON)
@@ -69,7 +69,7 @@ target_link_libraries(${PROJECT_LIB_NAME}
 	 ${Boost_LIBRARIES}
 	 ${ROOT_LIBRARIES}
 	 )
-	 
+
 # tests
 enable_testing()
 set(PROJECT_TEST_NAME ${PROJECT_NAME_STR}_test)
@@ -83,3 +83,8 @@ target_link_libraries(${PROJECT_TEST_NAME}
 	 )
 
 add_test(test1 ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_TEST_NAME})
+
+# install
+install(TARGETS ${PROJECT_LIB_NAME} ${PROJECT_TEST_NAME}
+        LIBRARY DESTINATION lib
+        RUNTIME DESTINATION bin)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,21 @@ link_directories(${Boost_LIBRARY_DIRS})
 
 #Check the compiler and set the compile and link flags
 set(CMAKE_BUILD_TYPE Release)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -std=c++11")
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3")
+# properly set the C++ standard according to the standard used for the root build
+# Enable C++11 by default if found in ROOT
+message(STATUS "Determining C++ standard ...")
+if(ROOT_HAS_CXX11 AND NOT DISABLE_CXX11)
+  message(STATUS "Enabling C++11")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+endif()
+
+# Enable C++14 by default if found in ROOT
+if(ROOT_HAS_CXX14 AND NOT DISABLE_CXX14)
+  message(STATUS "Enabling C++14")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
+endif()
 # first attempt to make cmake work again on OS X
 if((CMAKE_CXX_COMPILER_ID STREQUAL "Clang") AND (APPLE))
 	MESSAGE(STATUS "** std library for clang: libc++")

--- a/cmake/Modules/FindROOT.cmake
+++ b/cmake/Modules/FindROOT.cmake
@@ -268,6 +268,14 @@ IF( ROOT_CONFIG_EXECUTABLE )
         set(ROOT_HAS_CXX14 FALSE)
     endif()
 
+    # Check if ROOT was built with C++14 support
+    if(ROOT_CXX_FLAGS MATCHES "-std=c\\+\\+17" OR ROOT_CXX_FLAGS MATCHES "-std=c\\+\\+1z")
+        message(STATUS "ROOT was built with C++17 support")
+        set(ROOT_HAS_CXX14 TRUE)
+    else()
+        set(ROOT_HAS_CXX14 FALSE)
+    endif()
+
 ENDIF( ROOT_CONFIG_EXECUTABLE )
 
 # Threads library

--- a/cmake/Modules/FindROOT.cmake
+++ b/cmake/Modules/FindROOT.cmake
@@ -238,6 +238,36 @@ IF( ROOT_CONFIG_EXECUTABLE )
         MESSAGE( STATUS "Check for libdl.so: ${DL_LIB}" )
     ENDIF()
 
+    # Check for root-config scripts
+    #find_program(ROOT_CONFIG NAMES root-config PATHS ${ROOTSYS}/bin NO_DEFAULT_PATH)
+    #if(NOT ROOT_CONFIG)
+    #    message(FATAL_ERROR "Could not find root-config script.")
+    #endif(NOT ROOT_CONFIG)
+    #mark_as_advanced(ROOT_CONFIG)
+
+    # Setting ROOT compiler flags (except the -I parts) to a variable
+    execute_process(COMMAND ${ROOT_CONFIG_EXECUTABLE} --auxcflags OUTPUT_VARIABLE _ROOT_CXX_FLAGS ERROR_VARIABLE error OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if(error)
+        message(FATAL_ERROR "Error retrieving ROOT compiler flags: ${error}")
+    endif(error)
+    string(STRIP "${_ROOT_CXX_FLAGS}" ROOT_CXX_FLAGS)
+
+    # Check if ROOT was built with C++11 support
+    if(ROOT_CXX_FLAGS MATCHES "-std=c\\+\\+11")
+        message(STATUS "ROOT was built with C++11 support")
+        set(ROOT_HAS_CXX11 TRUE)
+    else()
+        set(ROOT_HAS_CXX11 FALSE)
+    endif()
+
+    # Check if ROOT was built with C++14 support
+    if(ROOT_CXX_FLAGS MATCHES "-std=c\\+\\+14" OR ROOT_CXX_FLAGS MATCHES "-std=c\\+\\+1y")
+        message(STATUS "ROOT was built with C++14 support")
+        set(ROOT_HAS_CXX14 TRUE)
+    else()
+        set(ROOT_HAS_CXX14 FALSE)
+    endif()
+
 ENDIF( ROOT_CONFIG_EXECUTABLE )
 
 # Threads library

--- a/cmake/Modules/FindROOT.cmake
+++ b/cmake/Modules/FindROOT.cmake
@@ -17,7 +17,7 @@
 #   ROOT_COMPONENT_LIBRARIES    : list of ROOT component libraries
 #   ROOT_${COMPONENT}_FOUND     : set to TRUE or FALSE for each library
 #   ROOT_${COMPONENT}_LIBRARY   : path to individual libraries
-#   
+#
 #
 #   Please note that by convention components should be entered exactly as
 #   the library names, i.e. the component name equivalent to the library
@@ -88,7 +88,7 @@ IF( ROOT_CONFIG_EXECUTABLE )
     # ==============================================
 
     INCLUDE( MacroCheckPackageVersion )
-    
+
     EXECUTE_PROCESS( COMMAND "${ROOT_CONFIG_EXECUTABLE}" --version
         OUTPUT_VARIABLE _version
         RESULT_VARIABLE _exit_code
@@ -105,7 +105,7 @@ IF( ROOT_CONFIG_EXECUTABLE )
     ENDIF()
 
     CHECK_PACKAGE_VERSION( ROOT ${ROOT_VERSION} )
-	
+
 	# find rootcint
 	SET( ROOT_CINT_EXECUTABLE ROOT_CINT_EXECUTABLE-NOTFOUND )
 	MARK_AS_ADVANCED( ROOT_CINT_EXECUTABLE )
@@ -179,7 +179,7 @@ IF( ROOT_CONFIG_EXECUTABLE )
         OUTPUT_STRIP_TRAILING_WHITESPACE
     )
     IF( _exit_code EQUAL 0 )
-        
+
         # create a list out of the output
         SEPARATE_ARGUMENTS( _aux )
 
@@ -200,6 +200,10 @@ IF( ROOT_CONFIG_EXECUTABLE )
             ENDIF()
 
         ENDFOREACH()
+
+        IF(NOT ROOT_VERSION_MAJOR LESS 6)
+	          LIST( APPEND _root_libnames Unfold )
+        ENDIF()
 
     ENDIF()
 
@@ -261,4 +265,3 @@ ENDIF( ROOT_FOUND )
 # FIND_PACKAGE( ROOT REQUIRED )
 # FIND_PACKAGE( ROOT COMPONENTS geartgeo QUIET )
 SET( ROOT_FIND_REQUIRED )
-

--- a/src/RooUnfold.cxx
+++ b/src/RooUnfold.cxx
@@ -80,6 +80,7 @@ END_HTML */
 #include "TDecompSVD.h"
 #include "TDecompChol.h"
 #include "TRandom.h"
+#include "TBuffer.h"
 
 #include "../include/RooUnfoldResponse.h"
 #include "../include/RooUnfoldErrors.h"

--- a/src/RooUnfoldResponse.cxx
+++ b/src/RooUnfoldResponse.cxx
@@ -33,6 +33,7 @@
 #include "TH3.h"
 #include "TVectorD.h"
 #include "TMatrixD.h"
+#include "TBuffer.h"
 
 using std::cout;
 using std::cerr;

--- a/src/RooUnfoldSvd.cxx
+++ b/src/RooUnfoldSvd.cxx
@@ -34,6 +34,7 @@ END_HTML */
 #include "TH2.h"
 #include "TVectorD.h"
 #include "TMatrixD.h"
+#include "TBuffer.h"
 #include "../include/TauSVDUnfold.h"
 
 #include "../include/RooUnfoldResponse.h"


### PR DESCRIPTION
Dear @kreczko,

In the transition of the ALICE software stack to ROOT6 we developed a few patches in order to enhance the compatibility of RooUnfold with ROOT6. Among these are:

- Automatic determination of the c++ standard covering c++98 - c++17
- Support for rootmap, installation of PCM files
- Adding missing includes

We would like to contribute with the patches to the base RooUnfold repository. Would you consider that our pull request is appropriate to be merged into your repository?

Thanks in advance!

Cheers

Markus 